### PR TITLE
Fix logBanner in node

### DIFF
--- a/src/utils/logBanner.js
+++ b/src/utils/logBanner.js
@@ -1,13 +1,29 @@
 /* eslint no-console: off */
-import { version } from '../../package.json'
+import { version, repository } from '../../package.json'
 
-// Display a nice banner in the browser console
+// Display a nice banner in the console
 export default function logBanner () {
-  console.log(`%cfae ♥ ${version}%c https://github.com/sambrosia/fae `, `
-    background: #aaf;
-    color: white;
-    line-height: 39px;
-    padding: 4px 10px;
-    border-radius: 30px;
-  `, 'color: #aaf;')
+  const message = `%cfae ♥ ${version}%c https://github.com/${repository} `
+
+  if (global.window) {
+    // Style with CSS in browsers
+    console.log(
+      message,
+      `
+        background: #aaf;
+        color: white;
+        line-height: 39px;
+        padding: 4px 10px;
+        border-radius: 30px;
+      `,
+      'color: #aaf;'
+    )
+  } else {
+    // Color with ANSI escape sequences in node
+    console.log(
+      message
+        .replace(/%c/, '\x1B[35m\x1b[1m')
+        .replace(/%c/, '\x1b[0m\x1b[35m')
+    )
+  }
 }


### PR DESCRIPTION
Fixes #6. For node, anyway. There doesn't seem to be a way to detect
support for %c formatting. I don't really want to do browser detection
to fix it in browsers that don't support it.

Maybe I'll change my mind later.